### PR TITLE
[LaTeX] Fix scope order in tabular environment

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -1708,13 +1708,12 @@ contexts:
       push:
         - meta_scope: meta.environment.tabular.latex
         - match: '\{'
-          scope: punctuation.definition.group.brace.begin.latex
+          scope: meta.function.column-spec.latex punctuation.definition.group.brace.begin.latex
           set:
-            - meta_scope: meta.function.column-spec.latex
-            - meta_content_scope: meta.environment.tabular.latex
+            - meta_content_scope: meta.environment.tabular.latex meta.function.column-spec.latex
             - include: array-preamble
             - match: '\}'
-              scope: punctuation.definition.group.brace.end.latex
+              scope: meta.function.column-spec.latex punctuation.definition.group.brace.end.latex
               set:
                 - meta_content_scope: meta.environment.tabular.latex
                 - match: '((\\)end)(\{)(tabular)(\})'

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -396,7 +396,7 @@ def my_function():
 
 \begin{tabular}[t]{|x|@{See: }>{$}l<{$}|}
 %^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.environment.tabular.latex - meta.environment.tabular.latex meta.environment.tabular.latex
-%                 ^^^^^^^^^^^^^^^^^^^^^^^ meta.function.column-spec.latex
+%                 ^^^^^^^^^^^^^^^^^^^^^^^ meta.environment.tabular.latex meta.function.column-spec.latex
 %                  ^ keyword.operator.inter-column-line.latex
 %                     ^ support.function.inter-column-nospace.latex
 


### PR DESCRIPTION
Currently the scope inside the braces is `meta.function.column-spec.latex meta.environment.tabular.latex` instead of `meta.environment.tabular.latex meta.function.column-spec.latex`.