### PR TITLE
[LaTeX] Only apply the tabular scope with correct syntax

### DIFF
--- a/LaTeX/LaTeX.sublime-syntax
+++ b/LaTeX/LaTeX.sublime-syntax
@@ -1697,6 +1697,7 @@ contexts:
         (?x)
         ((\\)begin)(\{)(tabular)(\})
         (?:(\[)(?:b|c|t)(\]))?
+        (?=\s*\{)
       captures:
         1: support.function.begin.latex keyword.control.flow.begin.latex
         2: punctuation.definition.backslash.latex

--- a/LaTeX/syntax_test_latex.tex
+++ b/LaTeX/syntax_test_latex.tex
@@ -394,6 +394,10 @@ def my_function():
 % The array package extends array and tabular environments
 % and allows for macros in format specifications
 
+\begin{tabular}
+% <- -meta.environment.tabular.latex
+\end{tabular}
+
 \begin{tabular}[t]{|x|@{See: }>{$}l<{$}|}
 %^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ meta.environment.tabular.latex - meta.environment.tabular.latex meta.environment.tabular.latex
 %                 ^^^^^^^^^^^^^^^^^^^^^^^ meta.function.column-spec.latex


### PR DESCRIPTION
The syntax breaks if you write 

``` latex
\begin{tabular}
...
\end{tabular}
```

instead of

``` latex
\begin{tabular}{|l|l|}
...
\end{tabular}
```